### PR TITLE
provide menu opt to pause monitoring when app is running

### DIFF
--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -15,6 +15,7 @@ type Clipboard struct {
 	LastText   string
 	Mu         sync.RWMutex
 	OutputText string
+	Disable    bool
 }
 
 func NewClipboard() *Clipboard {
@@ -27,20 +28,26 @@ func NewClipboard() *Clipboard {
 
 func (c *Clipboard) StartMonitoring() {
 	for {
-		c.Mu.Lock()
-		text, err := clipboard.ReadAll()
-		if err != nil || strings.TrimSpace(text) == "" {
+		switch {
+		case c.Disable:
+			time.Sleep(1 * time.Second)
+		default:
+			c.Mu.Lock()
+			text, err := clipboard.ReadAll()
+			if err != nil || strings.TrimSpace(text) == "" {
+				c.Mu.Unlock()
+				time.Sleep(100 * time.Millisecond) // Add a small delay to prevent tight looping
+				continue
+			}
+
+			if !isLikelyScreenshot(text) && text != c.LastText && text != c.OutputText {
+				c.LastText = text
+				c.Prompt <- text
+			}
 			c.Mu.Unlock()
 			time.Sleep(100 * time.Millisecond) // Add a small delay to prevent tight looping
-			continue
 		}
-
-		if !isLikelyScreenshot(text) && text != c.LastText && text != c.OutputText {
-			c.LastText = text
-			c.Prompt <- text
-		}
-		c.Mu.Unlock()
-		time.Sleep(100 * time.Millisecond) // Add a small delay to prevent tight looping
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 

--- a/panes/inputPane.go
+++ b/panes/inputPane.go
@@ -40,6 +40,8 @@ func init() {
 func StartClipboardMonitoring(app *tview.Application) {
 	clipboard.Clear()
 	clipboard := clipboard.NewClipboard()
+	ApplySystemNavConfig(app, clipboard)
+
 	var lastPublishedText string
 
 	go clipboard.StartMonitoring()

--- a/panes/layout.go
+++ b/panes/layout.go
@@ -37,12 +37,8 @@ func CreateMainFlex(group1 *tview.Flex, keybindingsPane *tview.TextView) *tview.
 }
 
 func SetupMainUILayout(app *tview.Application) {
-	if app == nil {
-		StartClipboardMonitoring(nil)
-		ApplySystemNavConfig(nil)
-
-		select {}
-	} else {
+	StartClipboardMonitoring(app)
+	if app != nil {
 		group2 := CreateGroup2(HistoryPane, ModelList)
 		group4 := CreateGroup4(InputPane, PromptPane)
 		group3 := CreateGroup3(group4, OutputPane)
@@ -70,10 +66,9 @@ func SetupMainUILayout(app *tview.Application) {
 		app.SetRoot(mainFlex, true)
 		log.Println("Running app for main UI.")
 
-		StartClipboardMonitoring(app)
-		ApplySystemNavConfig(app)
-
 		err := app.Run()
 		checkNilErr(err)
+	} else {
+		select {}
 	}
 }

--- a/panes/sysNavPane.go
+++ b/panes/sysNavPane.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 
+	"github.com/Codesmith28/lazyAi/internal/clipboard"
 	"github.com/getlantern/systray"
 	"github.com/rivo/tview"
 )
@@ -13,13 +14,14 @@ import (
 //go:embed lazyAi.ico
 var iconBytes []byte
 
-func ApplySystemNavConfig(app *tview.Application) {
+func ApplySystemNavConfig(app *tview.Application, clipboard *clipboard.Clipboard) {
 	onReady := func() {
 		systray.SetIcon(iconBytes)
 		systray.SetTitle("AI model is now on your clipboard!!")
 		systray.SetTooltip("Started!")
 
 		mQuit := systray.AddMenuItem("Quit", "Quit the whole app")
+		stopMonitoring := systray.AddMenuItem("Pause", "Pause the clipboard monitoring")
 
 		go func() {
 			<-mQuit.ClickedCh
@@ -27,6 +29,22 @@ func ApplySystemNavConfig(app *tview.Application) {
 				app.Stop()
 			}
 			systray.Quit()
+		}()
+
+		go func() {
+			for {
+				<-stopMonitoring.ClickedCh
+
+				if clipboard.Disable {
+					clipboard.Disable = false
+					stopMonitoring.SetTitle("Pause")
+					stopMonitoring.SetTooltip("Pause the clipboard monitoring")
+				} else {
+					clipboard.Disable = true
+					stopMonitoring.SetTitle("Resume")
+					stopMonitoring.SetTooltip("Resume the clipboard monitoring")
+				}
+			}
 		}()
 
 		c := make(chan os.Signal, 1)
@@ -46,5 +64,4 @@ func ApplySystemNavConfig(app *tview.Application) {
 }
 
 func onExit() {
-	// clean up here
 }


### PR DESCRIPTION
When app is running it constantly monitors clipboard, if scenario arises to do other activity involving the same, app needs to be stopped. Better way could be to support pausing the clipboard monitoring for that duration.

cc @Codesmith28 